### PR TITLE
Add postcode and country fields to users

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -1,5 +1,9 @@
-// Overrides and adds customized styles in this file
-// Read more on documentation:
-// * English: https://github.com/consul/consul/blob/master/CUSTOMIZE_EN.md#css
-// * Spanish: https://github.com/consul/consul/blob/master/CUSTOMIZE_ES.md#css
-//
+// Custom styles
+
+.auth-image {
+
+  @include breakpoint(medium) {
+    min-height: $line-height * 62;
+  }
+}
+

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -62,7 +62,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
       params[:user].delete(:redeemable_code) if params[:user].present? && params[:user][:redeemable_code].blank?
       params.require(:user).permit(:username, :email, :password,
                                    :password_confirmation, :terms_of_service, :locale,
-                                   :redeemable_code)
+                                   :redeemable_code, :postcode, :country)
     end
 
     def configure_permitted_parameters

--- a/app/views/admin/users/_users.html.erb
+++ b/app/views/admin/users/_users.html.erb
@@ -7,6 +7,8 @@
         <th scope="col"><%= t("admin.users.columns.name") %></th>
         <th scope="col"><%= t("admin.users.columns.email") %></th>
         <th scope="col"><%= t("admin.users.columns.document_number") %></th>
+        <th scope="col"><%= t("admin.users.columns.postcode") %></th>
+        <th scope="col"><%= t("admin.users.columns.country") %></th>
         <th scope="col"><%= t("admin.users.columns.roles") %></th>
         <th scope="col"><%= t("admin.users.columns.verification_level") %></th>
       </tr>
@@ -17,6 +19,8 @@
           <td><%= link_to user.name, user_path(user), target: "_blank" %></td>
           <td><%= user.email %></td>
           <td><%= user.document_number %></td>
+          <td><%= user.postcode %></td>
+          <td><%= user.country %></td>
           <td><%= display_user_roles(user) %></td>
           <td><%= user.user_type %></td>
         </tr>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -32,6 +32,12 @@
                            label: t("devise_views.users.registrations.new.password_confirmation_label"),
                            placeholder: t("devise_views.users.registrations.new.password_confirmation_label") %>
 
+      <%= f.text_field :postcode, autofocus: true, maxlength: 8,
+                                  hint: t("devise_views.users.registrations.new.postcode_note") %>
+
+      <%= f.text_field :country, autofocus: true,
+                                 hint: t("devise_views.users.registrations.new.country_note") %>
+
       <% if resource.use_redeemable_code %>
         <%= f.text_field :redeemable_code, placeholder: t("devise_views.users.registrations.new.redeemable_code") %>
       <% end %>

--- a/config/locales/en/activerecord.yml
+++ b/config/locales/en/activerecord.yml
@@ -260,6 +260,8 @@ en:
         recommended_debates: "Show debates recommendations"
         recommended_proposals: "Show proposals recommendations"
         redeemable_code: "Verification code received via email"
+        postcode: "Postcode"
+        country: "Country of residence"
       direct_message:
         title: "Title"
         body: "Message"

--- a/config/locales/en/admin.yml
+++ b/config/locales/en/admin.yml
@@ -1444,6 +1444,8 @@ en:
         document_number: Document number
         roles: Roles
         verification_level: Verification level
+        postcode: "Postcode"
+        country: "Country"
       index:
         title: User
         no_users: There are no users.

--- a/config/locales/en/devise_views.yml
+++ b/config/locales/en/devise_views.yml
@@ -121,6 +121,8 @@ en:
           username_is_not_available: Username already in use
           username_label: Username
           username_note: Name that appears next to your posts
+          postcode_note: "If you are a Citizen of Scotland please enter your postcode in the box, otherwise leave blank. This is for purposes of statistical & administrative detail and will not be published."
+          country_note: "Please enter your country of residence"
         success:
           back_to_index: I understand; go back to main page
           instructions_1: Please <b>check your email</b> - we have sent you a <b>link to confirm your account</b>.

--- a/db/migrate/20200706070528_add_fields_to_users.rb
+++ b/db/migrate/20200706070528_add_fields_to_users.rb
@@ -1,0 +1,15 @@
+class AddFieldsToUsers < ActiveRecord::Migration[5.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        add_column :users, :postcode, :string
+        add_column :users, :country, :string
+      end
+
+      dir.down do
+        remove_column :users, :postcode, :string
+        remove_column :users, :country, :string
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191108173350) do
+ActiveRecord::Schema.define(version: 20200706110055) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1483,6 +1483,8 @@ ActiveRecord::Schema.define(version: 20191108173350) do
     t.boolean  "public_interests",                          default: false
     t.boolean  "recommended_debates",                       default: true
     t.boolean  "recommended_proposals",                     default: true
+    t.string   "postcode"
+    t.string   "country"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["geozone_id"], name: "index_users_on_geozone_id", using: :btree

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe "Admin users" do
   let(:admin) { create(:administrator) }
-  let!(:user) { create(:user, username: "Jose Luis Balbin") }
+  let!(:user) { create(:user, username: "Jose Luis Balbin", postcode: "AB99", country: "Scotland") }
 
   before do
     login_as(admin.user)
@@ -14,6 +14,8 @@ describe "Admin users" do
     expect(page).to have_content user.email
     expect(page).to have_content admin.name
     expect(page).to have_content admin.email
+    expect(page).to have_content "AB99"
+    expect(page).to have_content "Scotland"
   end
 
   scenario "The username links to their public profile" do
@@ -30,5 +32,7 @@ describe "Admin users" do
     expect(page).to have_content user.email
     expect(page).not_to have_content admin.name
     expect(page).not_to have_content admin.email
+    expect(page).to have_content "AB99"
+    expect(page).to have_content "Scotland"
   end
 end

--- a/spec/features/users_auth_spec.rb
+++ b/spec/features/users_auth_spec.rb
@@ -12,6 +12,8 @@ describe "Users" do
         fill_in "user_email",                 with: "manuela@consul.dev"
         fill_in "user_password",              with: "judgementday"
         fill_in "user_password_confirmation", with: "judgementday"
+        fill_in "Postcode",                   with: "AB99"
+        fill_in "Country of residence",       with: "Scotland"
         check "user_terms_of_service"
 
         click_button "Register"


### PR DESCRIPTION
## Objectives

Add **postcode** and **country** optional fields to users sign up form. This information also appear on `admin/users` table.

## Visual Changes

### Signup form
![signup_form](https://user-images.githubusercontent.com/631897/86588737-8f604880-bf8c-11ea-89b5-e7eaa1953266.png)

### Admin users table
![admin](https://user-images.githubusercontent.com/631897/86588743-925b3900-bf8c-11ea-9162-bb081487a27d.png)
