### PR TITLE
Change redirect to root_path when hide user

### DIFF
--- a/app/controllers/moderation/users_controller.rb
+++ b/app/controllers/moderation/users_controller.rb
@@ -15,7 +15,7 @@ class Moderation::UsersController < Moderation::BaseController
   def hide
     block_user
 
-    redirect_to debates_path
+    redirect_to root_path
   end
 
   private

--- a/spec/features/admin/activity_spec.rb
+++ b/spec/features/admin/activity_spec.rb
@@ -206,7 +206,7 @@ describe "Admin activity" do
       within("#proposal_#{proposal.id}") do
         click_link "Hide author"
 
-        expect(page).to have_current_path(debates_path)
+        expect(page).to have_current_path(root_path)
       end
 
       visit admin_activity_path

--- a/spec/features/moderation/budget_investments_spec.rb
+++ b/spec/features/moderation/budget_investments_spec.rb
@@ -32,7 +32,7 @@ describe "Moderate budget investments" do
 
     accept_confirm { click_link "Hide author" }
 
-    expect(page).to have_current_path(debates_path)
+    expect(page).to have_current_path(root_path)
 
     visit budget_investments_path(budget.id, heading_id: heading.id)
 

--- a/spec/features/moderation/users_spec.rb
+++ b/spec/features/moderation/users_spec.rb
@@ -27,7 +27,7 @@ describe "Moderate users" do
       click_link "Hide author"
     end
 
-    expect(page).to have_current_path(debates_path)
+    expect(page).to have_current_path(root_path)
     expect(page).not_to have_content(debate1.title)
     expect(page).not_to have_content(debate2.title)
     expect(page).to have_content(debate3.title)


### PR DESCRIPTION
## Objectives

Now when using the "Hide author" link the page redirects to `debates_path` and may cause errors if that feature is disabled. This PR changes the redirect to `root_path` after hiding an author.

