### PR TITLE
Correctly set the votes counters

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -29,6 +29,7 @@ class CommentsController < ApplicationController
 
   def vote
     @comment.vote_by(voter: current_user, vote: params[:value])
+    @comment.set_votes_counter if @comment.commentable.is_a? Legislation::Question
     respond_with @comment
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -135,6 +135,13 @@ class Comment < ApplicationRecord
                                                              cached_votes_up)
   end
 
+  def set_votes_counter
+    self.cached_votes_total = self.find_votes_for.count
+    self.cached_votes_up = self.get_up_votes.count
+    self.cached_votes_down = self.get_down_votes.count
+    self.save(validate: false)
+  end
+
   private
 
     def validate_body_length

--- a/lib/tasks/comments.rake
+++ b/lib/tasks/comments.rake
@@ -1,0 +1,8 @@
+namespace :comments do
+  desc "Sets cached_votes_up, cached_votes_up, and cached_votes_up for Legislation::Question comments"
+  task set_votes_counter: :environment do
+    Comment.find_each do |comment|
+      comment.set_votes_counter if comment.commentable.is_a? Legislation::Question
+    end
+  end
+end

--- a/spec/features/comments/legislation_questions_spec.rb
+++ b/spec/features/comments/legislation_questions_spec.rb
@@ -171,6 +171,44 @@ describe "Commenting legislation questions" do
     end
   end
 
+  scenario "Votes are correctly counted for old ammendments with empty subject", :js do
+    user = create(:user, :level_two)
+    comment = create(:comment, commentable: legislation_question)
+    comment.subject = ""
+    comment.save(validate: false)
+
+    login_as(user)
+    visit legislation_process_question_path(legislation_question.process, legislation_question)
+
+    within("#comment_#{comment.id}_votes") do
+      find(".in_favor a").click
+
+      within(".in_favor") do
+        expect(page).to have_content "1"
+      end
+
+      within(".against") do
+        expect(page).to have_content "0"
+      end
+
+      expect(page).to have_content "1 vote"
+    end
+
+    visit legislation_process_question_path(legislation_question.process, legislation_question)
+
+    within("#comment_#{comment.id}_votes") do
+      within(".in_favor") do
+        expect(page).to have_content "1"
+      end
+
+      within(".against") do
+        expect(page).to have_content "0"
+      end
+
+      expect(page).to have_content "1 vote"
+    end
+  end
+
   scenario "Creation date works differently in roots and in child comments, even when sorting by confidence_score" do
     old_root = create(:comment, commentable: legislation_question, created_at: Time.current - 10)
     new_root = create(:comment, commentable: legislation_question, created_at: Time.current)


### PR DESCRIPTION
## Objectives

- Add a rake task to set the counters for already voted comments
- Fix the voting process to correctly update the counters for new votes

## Notes

Command to execute the rake
`bin/rake comments:set_votes_counter RAILS_ENV=production`